### PR TITLE
Copy ID to clipboard fix

### DIFF
--- a/ToastIntegrated/ChatUserIDsRedux/ChatUserIDsRedux.plugin.js
+++ b/ToastIntegrated/ChatUserIDsRedux/ChatUserIDsRedux.plugin.js
@@ -346,7 +346,7 @@ var ChatUserIDsRedux = (() => {
 
 			async double(e, author) {
 				try {
-					await window.navigator.clipboard.writeText(author.id);
+					await DiscordNative.clipboard.copy(author.id);
 					Toasts.info('Successfully copied!', { timeout: 2e3 });
 				} catch(error) {
 					err(error);


### PR DESCRIPTION
With the new Discord update you no longer seem to get access to the clipboard from the navigator object directly. Using the DiscordNative global to bypass this instead.