### PR TITLE
Added space between the dashes

### DIFF
--- a/ToastIntegrated/MemberCount/MemberCount.plugin.js
+++ b/ToastIntegrated/MemberCount/MemberCount.plugin.js
@@ -199,7 +199,7 @@ var MemberCount = (() => {
 								React.createElement('span', {
 									children: [
 										Counter.strings.MEMBERS,
-										'—',
+										' — ',
 										this.props.count
 									]
 								})


### PR DESCRIPTION
### Description

This pull request adds spaces after and before the dash.

### Example

**Before:** 
![image](https://user-images.githubusercontent.com/71038229/143626550-9155fa55-bfef-45c6-8761-4c99a387af45.png)


**After: (ignore the background change)** 
![image](https://user-images.githubusercontent.com/71038229/143626586-fe5b6341-183f-44d7-adb0-c354caa42db2.png)
