### PR TITLE
Make counter more integrated with themes

### DIFF
--- a/ToastIntegrated/MemberCount/MemberCount.plugin.js
+++ b/ToastIntegrated/MemberCount/MemberCount.plugin.js
@@ -682,14 +682,14 @@ var MemberCount = (() => {
 			get css() {
 				return `
 					#MemberCount {
-						background: var(--background-secondary);
+						background: rgba(0, 0, 0, calc(var(--background-shading) * 0.6));;
 						position: absolute;
 						width: 240px;
 						padding: 0;
 						z-index: 1;
 						top: 0;
 						margin-top: 0;
-						border-bottom: 1px solid hsla(0, 0%, 100%, 0.04);
+						border-bottom: 4px solid transparent;
 					}
 
 					#MemberCount h2 {


### PR DESCRIPTION
With themes the counter in grey and ugly, I made some change, you can check the difference :

Before: 
<img width="243" alt="image" src="https://user-images.githubusercontent.com/11821952/178122591-a33184e7-7bb7-4631-9af3-2bc1bb7b7458.png">


After: 
<img width="236" alt="image" src="https://user-images.githubusercontent.com/11821952/178122569-d31bba9a-b8db-44fb-8d06-5f863cdbf1a3.png">
